### PR TITLE
feat: Add clipboard support for images and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Dropover Changelog
 
+## [Add Clipboard Support] - 2025-01-28
+
+### New Features
+- **New Command: "Add Clipboard to Dropover"** - Add images or text directly from clipboard
+- Supports all major image formats:
+  - **Animated**: GIF
+  - **Modern**: WebP, HEIC, AVIF
+  - **Common**: PNG, JPEG, JPEG 2000
+  - **Legacy**: TIFF, BMP, ICO, PSD
+- Automatically saves clipboard images with correct file extensions
+- Text content is saved as `.txt` files and added to Dropover
+- Clear error messages for unsupported formats (videos, etc.)
+
+### Technical Improvements
+- Uses native macOS AppleScript for reliable clipboard image extraction
+- Fallback to PNG format when specific format extraction fails
+- Proper video format detection to show helpful error messages
+- **Auto-cleanup**: Temporary files older than 24 hours are automatically deleted
+
 ## [Fix special characters in filenames and update docs] - 2025-05-21
 
 - Fixed the issue with files containing special characters (like apostrophes and '#') failing to be added to Dropover

--- a/README.md
+++ b/README.md
@@ -2,11 +2,27 @@
 
 # Dropover Raycast Extension
 
-Add selected files to [Dropver](https://dropoverapp.com) with a single click from [Raycast](https://raycast.com).
+Add selected files to [Dropover](https://dropoverapp.com) with a single click from [Raycast](https://raycast.com).
 
 ## Installation
 
 [![Install Dropover Raycast Extension](https://www.raycast.com/jag-k/dropover/install_button@2x.png)](https://www.raycast.com/jag-k/dropover)
+
+## Features
+
+### 📁 Add to Dropover
+Add selected files from Finder directly to Dropover.
+
+### 📋 Add Clipboard to Dropover
+Add content from your clipboard to Dropover:
+
+- **Images**: Supports all major formats
+  - Animated: GIF
+  - Modern: WebP, HEIC, AVIF
+  - Common: PNG, JPEG, JPEG 2000
+  - Legacy: TIFF, BMP, ICO, PSD
+- **Text**: Saves as a `.txt` file and adds to Dropover
+- **Files**: Copied file paths are added directly
 
 ## Screenshots
 
@@ -15,5 +31,5 @@ Add selected files to [Dropver](https://dropoverapp.com) with a single click fro
 ## Links
 
 - Project GitHub: https://github.com/jag-k/dropover-raycast-extension
-- Author (me) GitHub: https://github.com/jag-k
+- Author GitHub: https://github.com/jag-k
 - Dropover site: https://dropoverapp.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,6 +426,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
       "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.57.0",
         "@typescript-eslint/types": "5.57.0",
@@ -642,6 +643,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -912,6 +914,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -1611,6 +1614,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
       "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -1663,6 +1667,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1989,6 +1994,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2336,6 +2342,7 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
           "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.57.0",
             "@typescript-eslint/types": "5.57.0",
@@ -2483,7 +2490,8 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2683,6 +2691,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -3228,7 +3237,8 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
       "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "progress": {
       "version": "2.0.3",
@@ -3252,6 +3262,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -3479,7 +3490,8 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "dropover",
   "title": "Dropover",
-  "description": "Add selected files to Dropover",
+  "description": "Add selected files or clipboard content to Dropover",
   "icon": "command-icon.png",
   "author": "jag-k",
+  "contributors": [
+    "dheeraj"
+  ],
   "categories": [
     "Applications",
     "Productivity"
@@ -15,6 +18,12 @@
       "name": "index",
       "title": "Add to Dropover",
       "description": "Add selected files to Dropover",
+      "mode": "no-view"
+    },
+    {
+      "name": "add-from-clipboard",
+      "title": "Add Clipboard to Dropover",
+      "description": "Add copied image or text from clipboard to Dropover",
       "mode": "no-view"
     }
   ],

--- a/raycast-env.d.ts
+++ b/raycast-env.d.ts
@@ -15,9 +15,13 @@ declare type Preferences = ExtensionPreferences
 declare namespace Preferences {
   /** Preferences accessible in the `index` command */
   export type Index = ExtensionPreferences & {}
+  /** Preferences accessible in the `add-from-clipboard` command */
+  export type AddFromClipboard = ExtensionPreferences & {}
 }
 
 declare namespace Arguments {
   /** Arguments passed to the `index` command */
   export type Index = {}
+  /** Arguments passed to the `add-from-clipboard` command */
+  export type AddFromClipboard = {}
 }

--- a/src/add-from-clipboard.ts
+++ b/src/add-from-clipboard.ts
@@ -1,0 +1,280 @@
+import { Clipboard, environment, showHUD } from "@raycast/api";
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Execute a command and return the output as a promise
+ */
+function spawnPromise(command: string, args: string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const process = spawn(command, args, { shell: false });
+
+    let stdout = "";
+    let stderr = "";
+
+    process.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    process.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    process.on("close", (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`Command failed with code ${code}: ${stderr}`));
+      }
+    });
+
+    process.on("error", reject);
+  });
+}
+
+/**
+ * Add a file to Dropover
+ */
+async function addToDropover(filePath: string): Promise<void> {
+  const args = ["-b", "me.damir.dropover-mac", filePath];
+  await spawnPromise("open", args);
+}
+
+// Maximum age for temporary files (24 hours in milliseconds)
+const MAX_FILE_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Clean up old clipboard files from the support directory
+ * Removes files older than 24 hours to prevent storage buildup
+ */
+function cleanupOldFiles(supportPath: string): void {
+  try {
+    if (!fs.existsSync(supportPath)) return;
+
+    const now = Date.now();
+    const files = fs.readdirSync(supportPath);
+
+    for (const file of files) {
+      // Only clean up clipboard-related files
+      if (!file.startsWith("clipboard-")) continue;
+
+      const filePath = path.join(supportPath, file);
+      try {
+        const stats = fs.statSync(filePath);
+        const fileAge = now - stats.mtimeMs;
+
+        if (fileAge > MAX_FILE_AGE_MS) {
+          fs.unlinkSync(filePath);
+        }
+      } catch {
+        // Ignore errors for individual files
+      }
+    }
+  } catch {
+    // Silently ignore cleanup errors
+  }
+}
+
+// Image format definitions with clipboard class identifiers
+interface ImageFormat {
+  name: string;
+  extension: string;
+  clipboardClass: string;
+  clipboardIndicator: string;
+}
+
+const IMAGE_FORMATS: ImageFormat[] = [
+  // Common formats first - PNG is preferred for screenshots
+  { name: "PNG", extension: ".png", clipboardClass: "«class PNGf»", clipboardIndicator: "«class PNGf»" },
+  { name: "JPEG", extension: ".jpg", clipboardClass: "JPEG picture", clipboardIndicator: "JPEG picture" },
+
+  // Modern formats
+  { name: "WebP", extension: ".webp", clipboardClass: "«class WebP»", clipboardIndicator: "«class WebP»" },
+  { name: "HEIC", extension: ".heic", clipboardClass: "«class heic»", clipboardIndicator: "«class heic»" },
+  { name: "AVIF", extension: ".avif", clipboardClass: "«class AVIF»", clipboardIndicator: "«class AVIF»" },
+
+  // GIF - check after common formats (macOS provides GIF conversion for most images)
+  { name: "GIF", extension: ".gif", clipboardClass: "«class GIFf»", clipboardIndicator: "GIF picture" },
+
+  // Other formats
+  { name: "JPEG 2000", extension: ".jp2", clipboardClass: "«class jp2 »", clipboardIndicator: "«class jp2 »" },
+  { name: "TIFF", extension: ".tiff", clipboardClass: "TIFF picture", clipboardIndicator: "TIFF picture" },
+  { name: "BMP", extension: ".bmp", clipboardClass: "«class BMP »", clipboardIndicator: "«class BMP »" },
+  { name: "ICO", extension: ".ico", clipboardClass: "«class icns»", clipboardIndicator: "«class icns»" },
+  { name: "PSD", extension: ".psd", clipboardClass: "«class 8BPS»", clipboardIndicator: "«class 8BPS»" },
+];
+
+// Video formats to detect (not supported)
+const VIDEO_INDICATORS = [
+  "«class M4V »",
+  "«class mp4v»",
+  "«class mpg4»",
+  "«class MOV »",
+  "«class mov »",
+  "«class AVI »",
+  "«class avi »",
+  "«class MKV »",
+  "«class mkv »",
+  "«class WebM»",
+  "«class webm»",
+  "Movie",
+  "QuickTime",
+];
+
+/**
+ * Get clipboard info to detect available formats
+ */
+async function getClipboardInfo(): Promise<string> {
+  try {
+    return await spawnPromise("osascript", ["-e", "clipboard info"]);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Check if clipboard contains video content
+ */
+function hasVideoContent(clipboardInfo: string): boolean {
+  return VIDEO_INDICATORS.some((indicator) => clipboardInfo.includes(indicator));
+}
+
+/**
+ * Detect which image format is available in clipboard
+ * Uses the ORDER from clipboard info - first format is typically the original
+ */
+async function detectClipboardImageFormat(): Promise<ImageFormat | null> {
+  const info = await getClipboardInfo();
+  if (!info) return null;
+
+  // Find the first matching format based on position in clipboard info
+  // The first format in the clipboard info is typically the primary/original format
+  let bestFormat: ImageFormat | null = null;
+  let bestPosition = Infinity;
+
+  for (const format of IMAGE_FORMATS) {
+    const position = info.indexOf(format.clipboardIndicator);
+    if (position !== -1 && position < bestPosition) {
+      bestPosition = position;
+      bestFormat = format;
+    }
+  }
+
+  return bestFormat;
+}
+
+/**
+ * Save clipboard image to a file using osascript
+ */
+async function saveClipboardImage(outputPath: string, format: ImageFormat): Promise<boolean> {
+  try {
+    // Use osascript to write clipboard image data to file
+    const script = `
+      set thePath to POSIX file "${outputPath}"
+      set imageData to the clipboard as ${format.clipboardClass}
+      set fileRef to open for access thePath with write permission
+      set eof of fileRef to 0
+      write imageData to fileRef
+      close access fileRef
+      return "success"
+    `;
+    await spawnPromise("osascript", ["-e", script]);
+    return fs.existsSync(outputPath);
+  } catch {
+    // If the specific format fails, try PNG as fallback
+    if (format.extension !== ".png") {
+      try {
+        const pngPath = outputPath.replace(format.extension, ".png");
+        const pngScript = `
+          set thePath to POSIX file "${pngPath}"
+          set imageData to the clipboard as «class PNGf»
+          set fileRef to open for access thePath with write permission
+          set eof of fileRef to 0
+          write imageData to fileRef
+          close access fileRef
+          return "success"
+        `;
+        await spawnPromise("osascript", ["-e", pngScript]);
+        return fs.existsSync(pngPath);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Main command: Add clipboard content to Dropover
+ */
+export default async function main() {
+  try {
+    // Ensure support directory exists
+    const supportPath = environment.supportPath;
+    if (!fs.existsSync(supportPath)) {
+      fs.mkdirSync(supportPath, { recursive: true });
+    }
+
+    // Clean up old temporary files (older than 24 hours)
+    cleanupOldFiles(supportPath);
+
+    // Get clipboard info for format detection
+    const clipboardInfo = await getClipboardInfo();
+
+    // Check if clipboard contains video (not supported)
+    if (clipboardInfo && hasVideoContent(clipboardInfo)) {
+      await showHUD("🎬 Videos are not supported! Only images and text.");
+      return;
+    }
+
+    // Check if clipboard has image data
+    const imageFormat = await detectClipboardImageFormat();
+    if (imageFormat) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const imagePath = path.join(supportPath, `clipboard-image-${timestamp}${imageFormat.extension}`);
+
+      const saved = await saveClipboardImage(imagePath, imageFormat);
+      if (saved) {
+        await addToDropover(imagePath);
+        await showHUD(`📎 Added ${imageFormat.name} image to Dropover`);
+        return;
+      } else {
+        await showHUD(`❌ Failed to save ${imageFormat.name} image from clipboard`);
+        return;
+      }
+    }
+
+    // Fallback: Read clipboard content using Raycast API
+    const clipboardContent = await Clipboard.read();
+
+    // Check if clipboard contains a file path
+    if (clipboardContent.file) {
+      await addToDropover(clipboardContent.file);
+      await showHUD("📎 Added file from clipboard to Dropover");
+      return;
+    }
+
+    // Check if clipboard contains text
+    if (clipboardContent.text) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const textFilePath = path.join(supportPath, `clipboard-text-${timestamp}.txt`);
+
+      fs.writeFileSync(textFilePath, clipboardContent.text, "utf-8");
+
+      await addToDropover(textFilePath);
+      await showHUD("📎 Added text from clipboard to Dropover");
+      return;
+    }
+
+    // No supported content in clipboard
+    if (clipboardInfo) {
+      await showHUD("❌ Unsupported format! Only images and text are supported.");
+    } else {
+      await showHUD("📋 Clipboard is empty");
+    }
+  } catch (error) {
+    console.error(error);
+    await showHUD("📛 Failed to add clipboard content to Dropover!");
+  }
+}


### PR DESCRIPTION
- New command: Add Clipboard to Dropover
- Supports all major image formats (PNG, JPEG, GIF, WebP, HEIC, AVIF, TIFF, BMP, ICO, PSD)
- Smart format detection preserves original format from clipboard
- Text clipboard saves as .txt file and adds to Dropover
- Video detection with helpful error message
- Auto-cleanup: removes temporary files older than 24 hours
- Clear error messages for unsupported formats